### PR TITLE
Add deployed field to install KubeStateMetrics, Grafana and NodeExpor…

### DIFF
--- a/stable/prometheus-operator/requirements.yaml
+++ b/stable/prometheus-operator/requirements.yaml
@@ -3,14 +3,14 @@ dependencies:
   - name: kube-state-metrics
     version: 1.6.*
     repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: kubeStateMetrics.enabled
+    condition: kubeStateMetrics.deployed
 
   - name: prometheus-node-exporter
     version: 1.5.*
     repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: nodeExporter.enabled
+    condition: nodeExporter.deployed
 
   - name: grafana
     version: 3.3.*
     repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: grafana.enabled
+    condition: grafana.deployed

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -364,6 +364,7 @@ alertmanager:
 ##
 grafana:
   enabled: true
+  deployed: true
 
   ## Deploy default dashboards.
   ##
@@ -776,6 +777,7 @@ kubeScheduler:
 ##
 kubeStateMetrics:
   enabled: true
+  deployed: true
   serviceMonitor:
     ## Scrape interval. If not set, the Prometheus default scrape interval is used.
     ##
@@ -810,6 +812,7 @@ kube-state-metrics:
 ##
 nodeExporter:
   enabled: true
+  deployed: true
 
   ## Use the value configured in prometheus-node-exporter.podLabels
   ##


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6204

As we agreed to use the Official Prometheus Operator Chart we need to provide some changes upstream to make it functional in our TCs. First change I would like to propose is to make the KubeStateMetrics, Grafana and NodeExporter charts optional (deployment) but let the `ServiceMonitor` so we can reuse our existing components.